### PR TITLE
Correct version of Google config for eslint

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Default eslint configuration for nodejs services
 You'll first need to install [ESLint](http://eslint.org):
 
 ```
-$ npm i eslint eslint-plugin-import eslint-plugin-node eslint-plugin-promise eslint-config-google --save-dev
+$ npm i eslint eslint-plugin-import eslint-plugin-node eslint-plugin-promise eslint-config-google@0.6.0 --save-dev
 ```
 
 Next, install `eslint-config-sunset-nodejs`:


### PR DESCRIPTION
Just a minor change to set our Linter to work with the correct version of Google config. 

When using the most recent version, the Linter was not in accordance to the ones used in all other services.